### PR TITLE
package.json: fix dependency conflict

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "enzyme": "3.11.0",
     "enzyme-adapter-react-16": "1.15.5",
     "enzyme-to-json": "3.6.1",
-    "eslint": "6.1.0",
+    "eslint": "^5.0.0",
     "eslint-plugin-react": "7.16.0",
     "gulp": "4.0.2",
     "jest": "24.8.0",


### PR DESCRIPTION
There's a dependency conflict that causes an error when attempting to run `npm install`.

I had to set the eslint version to "^5.0.0" for it to work. This PR fixes it.

Below the log output:
```
# npm resolution error report

While resolving: @typescript-eslint/eslint-plugin@1.13.0
Found: eslint@6.1.0
node_modules/eslint
  dev eslint@"6.1.0" from the root project
  peer eslint@"*" from @typescript-eslint/experimental-utils@1.13.0
  node_modules/@typescript-eslint/experimental-utils
    @typescript-eslint/experimental-utils@"1.13.0" from @typescript-eslint/eslint-plugin@1.13.0
    node_modules/@typescript-eslint/eslint-plugin
      dev @typescript-eslint/eslint-plugin@"1.13.0" from the root project
    @typescript-eslint/experimental-utils@"1.13.0" from @typescript-eslint/parser@1.13.0
    node_modules/@typescript-eslint/parser
      dev @typescript-eslint/parser@"1.13.0" from the root project
      peer @typescript-eslint/parser@"^1.9.0" from @typescript-eslint/eslint-plugin@1.13.0
      node_modules/@typescript-eslint/eslint-plugin
        dev @typescript-eslint/eslint-plugin@"1.13.0" from the root project
  peer eslint@"^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0" from eslint-plugin-react@7.16.0
  node_modules/eslint-plugin-react
    dev eslint-plugin-react@"7.16.0" from the root project

Could not resolve dependency:
peer eslint@"^5.0.0" from @typescript-eslint/eslint-plugin@1.13.0
node_modules/@typescript-eslint/eslint-plugin
  dev @typescript-eslint/eslint-plugin@"1.13.0" from the root project

Conflicting peer dependency: eslint@5.16.0
node_modules/eslint
  peer eslint@"^5.0.0" from @typescript-eslint/eslint-plugin@1.13.0
  node_modules/@typescript-eslint/eslint-plugin
    dev @typescript-eslint/eslint-plugin@"1.13.0" from the root project

Fix the upstream dependency conflict, or retry
this command with --force or --legacy-peer-deps
to accept an incorrect (and potentially broken) dependency resolution.
```