### PR TITLE
Add Game Media Carousel for Game Sidebar

### DIFF
--- a/src/back/game/GameManager.ts
+++ b/src/back/game/GameManager.ts
@@ -6,7 +6,7 @@ import * as fs from "fs";
 import * as path from "path";
 import * as chokidar from "chokidar";
 import { promisify } from "util";
-import { copyError, loadGameImages, walkSync } from "../util/misc";
+import { copyError, loadGameMedia, walkSync } from "../util/misc";
 import { GameManagerState, LoadPlatformError, ThumbnailList } from "./types";
 import {
     PlaylistManager,
@@ -22,7 +22,7 @@ import {
     orderGames,
 } from "@shared/game/GameFilter";
 import { readPlatformsFile } from "@back/platform/PlatformFile";
-import { findGameImageCollection } from "@back/util/images";
+import { findGameImageCollection, findGameVideos } from "@back/util/images";
 
 const readFile = promisify(fs.readFile);
 const stat = promisify(fs.stat);
@@ -364,9 +364,12 @@ export class GameManager {
 
                     // Load images
                     const imagesRoot = path.join(exodosPath, imagesPath, platform.name);
+                    const videoRoot = path.join(exodosPath, "Videos", platform.name);
                     const images = await findGameImageCollection(imagesRoot);
+                    const videos = findGameVideos(videoRoot);
+                    console.log(JSON.stringify(videos, undefined, 2));
                     for (const game of platform.collection.games) {
-                        loadGameImages(game, images);
+                        loadGameMedia(game, images, videos);
                     }
 
                     // Success!

--- a/src/back/game/GameManager.ts
+++ b/src/back/game/GameManager.ts
@@ -6,8 +6,8 @@ import * as fs from "fs";
 import * as path from "path";
 import * as chokidar from "chokidar";
 import { promisify } from "util";
-import { copyError, walkSync } from "../util/misc";
-import { GameManagerState, LoadPlatformError } from "./types";
+import { copyError, loadGameImages, walkSync } from "../util/misc";
+import { GameManagerState, LoadPlatformError, ThumbnailList } from "./types";
 import {
     PlaylistManager,
     PlaylistUpdatedFunc,
@@ -22,7 +22,7 @@ import {
     orderGames,
 } from "@shared/game/GameFilter";
 import { readPlatformsFile } from "@back/platform/PlatformFile";
-import { fixSlashes } from "@shared/Util";
+import { findGameImageCollection } from "@back/util/images";
 
 const readFile = promisify(fs.readFile);
 const stat = promisify(fs.stat);
@@ -43,6 +43,7 @@ export interface IGameManagerOpts {
     exodosPath: string;
     platformsPath: string;
     playlistFolder: string;
+    imagesPath: string;
     onPlaylistAddOrUpdate: PlaylistUpdatedFunc;
     log: LogFunc;
 }
@@ -90,7 +91,8 @@ export class GameManager {
         // GET ALL IMAGES ON GET GAME
         const platformErrors = await this.loadPlatforms(
             opts.platformsPath,
-            opts.exodosPath
+            opts.exodosPath,
+            opts.imagesPath,
         );
         this.platforms
             .filter((p) => p.isGamePlatform)
@@ -294,7 +296,8 @@ export class GameManager {
 
     private async loadPlatforms(
         platformsPath: string,
-        exodosPath: string
+        exodosPath: string,
+        imagesPath: string,
     ): Promise<LoadPlatformError[]> {
         this._state.platformsPath = platformsPath;
         const platforms: GamePlatform[] = [];
@@ -355,31 +358,17 @@ export class GameManager {
                             `Failed to parse XML file: ${platform.filePath}`
                         );
                     }
-
-                    // Populate platform
+                    
+                    // Load games
                     platform.collection = GameParser.parse(data, platform.name);
-                    const thumbnails = this._getThumbnailsForPlatform(
-                        exodosPath,
-                        platform
-                    );
-                    platform.collection.games.forEach((g) => {
-                        const imagesForGame = thumbnails.find(
-                            (i) => i.GameName == g.title
-                        );
-                        if (imagesForGame) {
-                            // The fileserver wants the relative path, not the full path on disk.
-                            // We know it always follows the format `/Images/<platform>/...`, so we split here on the assumption it will never appear earlier in the path. What are the odds?
-                            const parts = fixSlashes(
-                                imagesForGame.BoxThumbnail
-                            ).split(`Images/${platform.name}/`);
-                            if (parts.length > 1) {
-                                g.thumbnailPath = `Images/${platform.name}/${parts[1]}`;
-                            } else {
-                                // Failed to find relative path, ignore instead of throwing
-                                g.thumbnailPath = imagesForGame.BoxThumbnail;
-                            }
-                        }
-                    });
+
+                    // Load images
+                    const imagesRoot = path.join(exodosPath, imagesPath, platform.name);
+                    const images = await findGameImageCollection(imagesRoot);
+                    for (const game of platform.collection.games) {
+                        loadGameImages(game, images);
+                    }
+
                     // Success!
                     this._state.platforms.push(platform);
                 } catch (e) {
@@ -398,28 +387,37 @@ export class GameManager {
     private _getThumbnailsForPlatform(
         exodosPath: string,
         platform: GamePlatform
-    ): IImageInfo[] {
-        const boxImagesPath = path.join(
-            exodosPath,
-            `Images/${platform.name}/Box - Front`
-        );
+    ): ThumbnailList {
+        // Find thumbnail images in order of preference
+        const categoryOrder = [
+            'Box - Front',
+            'Box - Front - Reconstructed',
+            'Clear Logo',
+            'Screenshot - Game Title',
+        ];
 
-        console.info(
-            `Loading thumbnails from "${boxImagesPath}" path for ${platform.name} platform.`
-        );
-        const thumbnails: IImageInfo[] = [];
-        try {
-            for (const s of walkSync(boxImagesPath)) {
-                // filename to id
-                const coverPath = s.path.replace("../", "");
-                thumbnails.push({
-                    GameName: s.filename.replace("_", ":").split("-0")[0],
-                    BoxThumbnail: coverPath,
-                });
+        const thumbnails: ThumbnailList = {};
+
+        // For each category, store each found game if it isn't already stored
+        for (const category of categoryOrder) {
+            const boxImagesPath = path.join(exodosPath, `Images/${platform.name}/${category}`);
+            console.info(
+                `Loading thumbnails from "${boxImagesPath}" path for ${platform.name} platform.`
+            );
+            try {
+                for (const s of walkSync(boxImagesPath)) {
+                    const lastIdx = s.filename.lastIndexOf("-0");
+                    if (lastIdx > -1) {
+                        const gameName = s.filename.slice(0, lastIdx);
+                        if (!thumbnails[gameName]) {
+                            thumbnails[gameName] = s.path.replace("../", "");
+                        }
+                    }
+                }
+            } catch (e) {
+                console.error(`Error while loading thumbnails: ${e}`);
+                console.error(`Thumbnails not loaded.`);
             }
-        } catch (e) {
-            console.error(`Error while loading thumbnails: ${e}`);
-            console.error(`Thumbnails not loaded.`);
         }
         return thumbnails;
     }

--- a/src/back/game/LaunchBoxHelper.ts
+++ b/src/back/game/LaunchBoxHelper.ts
@@ -43,3 +43,8 @@ export function formatPlatformFileData(data: any): data is IRawPlatformFile {
         }
     }
 }
+
+// Change a string to work with the Launchbox images / filename structure
+export function getLaunchboxFilename(str: string): string {
+    return str.replace(/[';:?]/g, '_'); // Replace some characters with underscores
+}

--- a/src/back/game/types.ts
+++ b/src/back/game/types.ts
@@ -31,3 +31,7 @@ export type LoadPlatformError = ErrorCopy & {
     /** File path of the platform file the error is related to. */
     filePath: string;
 };
+
+export type ThumbnailList = {
+    [key: string]: string;
+};

--- a/src/back/index.ts
+++ b/src/back/index.ts
@@ -59,7 +59,6 @@ import * as http from "http";
 import * as path from "path";
 import * as WebSocket from "ws";
 import { v4 as uuid } from "uuid";
-
 import { EventEmitter } from "events";
 import { ConfigFile } from "./config/ConfigFile";
 import { loadExecMappingsFile } from "./Execs";
@@ -265,6 +264,7 @@ async function initializeGameManager() {
             exodosPath: state.config.exodosPath,
             platformsPath,
             playlistFolder,
+            imagesPath: state.config.imageFolderPath,
             onPlaylistAddOrUpdate,
             log,
         });

--- a/src/back/util/images.ts
+++ b/src/back/util/images.ts
@@ -1,4 +1,4 @@
-import { GameImagesCollection, IGameInfo } from '@shared/game/interfaces';
+import { GameImagesCollection, GameVideosCollection, IGameInfo } from '@shared/game/interfaces';
 import * as fs from 'fs';
 import * as path from 'path';
 import { walkSync } from './misc';
@@ -26,4 +26,15 @@ export async function findGameImageCollection(platImagesPath: string): Promise<G
     }
 
     return collection;
+}
+
+export function findGameVideos(videoPath: string): GameVideosCollection {
+    const videos: GameVideosCollection = {};
+
+    const files = fs.readdirSync(videoPath).filter(f => f.endsWith('.mp4'));
+    for (const s of files) {
+        videos[s.split('.mp4')[0]] = s;
+    }
+
+    return videos;
 }

--- a/src/back/util/images.ts
+++ b/src/back/util/images.ts
@@ -1,0 +1,29 @@
+import { GameImagesCollection, IGameInfo } from '@shared/game/interfaces';
+import * as fs from 'fs';
+import * as path from 'path';
+import { walkSync } from './misc';
+
+// Finds a list of all game images, returned in a map where the key is the type of image, and the value is an array of filenames
+export async function findGameImageCollection(platImagesPath: string): Promise<GameImagesCollection> {
+    const rootFolders = await fs.promises.readdir(platImagesPath, { withFileTypes: true });
+    const collection: GameImagesCollection = {};
+
+    for (const dir of rootFolders.filter(f => f.isDirectory())) {
+        collection[dir.name] = {}; // Initialize the image category
+        const folderPath = path.join(platImagesPath, dir.name);
+
+        for (const s of walkSync(folderPath)) {
+            const lastIdx = s.filename.lastIndexOf("-0");
+            if (lastIdx > -1) {
+                const title = s.filename.slice(0, lastIdx);
+                if (!collection[dir.name][title]) {
+                    collection[dir.name][title] = [path.relative(platImagesPath, s.path)];
+                } else {
+                    collection[dir.name][title].push(path.relative(platImagesPath, s.path));
+                }
+            }
+        }
+    }
+
+    return collection;
+}

--- a/src/back/util/misc.ts
+++ b/src/back/util/misc.ts
@@ -1,6 +1,6 @@
 import { getLaunchboxFilename } from "@back/game/LaunchBoxHelper";
 import { fixSlashes } from "@shared/Util";
-import { GameImagesCollection, IGameInfo } from "@shared/game/interfaces";
+import { GameImagesCollection, GameVideosCollection, IGameInfo } from "@shared/game/interfaces";
 import { DeepPartial } from "@shared/interfaces";
 import { IFileInfo } from "@shared/platform/interfaces";
 import * as fs from "fs";
@@ -119,13 +119,13 @@ const thumbnailPreference = [
     'Screenshot - Game Title',
 ];
 
-export function loadGameImages(game: IGameInfo, images: GameImagesCollection) {
+export function loadGameMedia(game: IGameInfo, images: GameImagesCollection, videos: GameVideosCollection) {
     const formattedGameTitle = getLaunchboxFilename(game.title);
 
     // Load all images
     for (const category of Object.keys(images)) {
         if (images[category][formattedGameTitle]) {
-            game.images[category] = images[category][formattedGameTitle];
+            game.media.images[category] = images[category][formattedGameTitle];
         }
     }
 
@@ -135,5 +135,16 @@ export function loadGameImages(game: IGameInfo, images: GameImagesCollection) {
             game.thumbnailPath = `Images/${game.platform}/${fixSlashes(images[preference][formattedGameTitle][0])}`;
             return;
         }
+    }
+
+    // Load videos
+    try {
+        const formattedGamePath = path.basename(fixSlashes(game.applicationPath)).split('.bat')[0];
+
+        if (videos[formattedGamePath]) {
+            game.media.video = `Videos/${game.platform}/${videos[formattedGamePath]}`;
+        }
+    } catch {
+        // Ignore, files don't exist if path isn't forming
     }
 }

--- a/src/back/util/misc.ts
+++ b/src/back/util/misc.ts
@@ -129,14 +129,6 @@ export function loadGameMedia(game: IGameInfo, images: GameImagesCollection, vid
         }
     }
 
-    // Load thumbnail path
-    for (const preference of thumbnailPreference) {
-        if (images[preference] && images[preference][formattedGameTitle]) {
-            game.thumbnailPath = `Images/${game.platform}/${fixSlashes(images[preference][formattedGameTitle][0])}`;
-            return;
-        }
-    }
-
     // Load videos
     try {
         const formattedGamePath = path.basename(fixSlashes(game.applicationPath)).split('.bat')[0];
@@ -146,5 +138,13 @@ export function loadGameMedia(game: IGameInfo, images: GameImagesCollection, vid
         }
     } catch {
         // Ignore, files don't exist if path isn't forming
+    }
+
+    // Load thumbnail path
+    for (const preference of thumbnailPreference) {
+        if (images[preference] && images[preference][formattedGameTitle]) {
+            game.thumbnailPath = `Images/${game.platform}/${fixSlashes(images[preference][formattedGameTitle][0])}`;
+            return;
+        }
     }
 }

--- a/src/back/util/misc.ts
+++ b/src/back/util/misc.ts
@@ -115,6 +115,7 @@ export function difObjects<T>(
 const thumbnailPreference = [
     'Box - Front',
     'Box - Front - Reconstructed',
+    'Fanart - Box - Front',
     'Clear Logo',
     'Screenshot - Game Title',
 ];

--- a/src/back/util/misc.ts
+++ b/src/back/util/misc.ts
@@ -1,3 +1,6 @@
+import { getLaunchboxFilename } from "@back/game/LaunchBoxHelper";
+import { fixSlashes } from "@shared/Util";
+import { GameImagesCollection, IGameInfo } from "@shared/game/interfaces";
 import { DeepPartial } from "@shared/interfaces";
 import { IFileInfo } from "@shared/platform/interfaces";
 import * as fs from "fs";
@@ -107,4 +110,30 @@ export function difObjects<T>(
         }
     }
     return dif;
+}
+
+const thumbnailPreference = [
+    'Box - Front',
+    'Box - Front - Reconstructed',
+    'Clear Logo',
+    'Screenshot - Game Title',
+];
+
+export function loadGameImages(game: IGameInfo, images: GameImagesCollection) {
+    const formattedGameTitle = getLaunchboxFilename(game.title);
+
+    // Load all images
+    for (const category of Object.keys(images)) {
+        if (images[category][formattedGameTitle]) {
+            game.images[category] = images[category][formattedGameTitle];
+        }
+    }
+
+    // Load thumbnail path
+    for (const preference of thumbnailPreference) {
+        if (images[preference] && images[preference][formattedGameTitle]) {
+            game.thumbnailPath = `Images/${game.platform}/${fixSlashes(images[preference][formattedGameTitle][0])}`;
+            return;
+        }
+    }
 }

--- a/src/renderer/Util.ts
+++ b/src/renderer/Util.ts
@@ -113,11 +113,6 @@ export function checkIfAncestor(
     return false;
 }
 
-export function getGameThumbnailUrl(thumbnailPath: string): string {
-    if (!thumbnailPath) return "";
-    return `${getFileServerURL()}/${thumbnailPath}`;
-}
-
 export function getGameTitleScreenshotUrl(
     platform: string,
     gameName: string
@@ -128,19 +123,13 @@ export function getGameTitleScreenshotUrl(
     )}-01.png`;
 }
 
-export function getPlatformIconURL(platform: string): string {
-    return `${getFileServerURL()}/Images/Platforms/${platform}/Clear Logo/${platform}.png`;
+export function getGameThumbnailUrl(thumbnailPath: string): string {
+    if (!thumbnailPath) return "";
+    return `${getFileServerURL()}/${thumbnailPath}`;
 }
 
-export function getGameScreenshotImageURL(
-    platform: string,
-    gameName: string,
-    idx: number = 1
-): string {
-    return `${getFileServerURL()}/Images/${platform}/Screenshot - Gameplay/${gameName.replace(
-        ":",
-        "_"
-    )}-0${idx}.png`;
+export function getPlatformIconURL(platform: string): string {
+    return `${getFileServerURL()}/Images/Platforms/${platform}/Clear Logo/${platform}.png`;
 }
 
 export async function resourceExists(url: string): Promise<boolean> {
@@ -151,19 +140,6 @@ export async function resourceExists(url: string): Promise<boolean> {
         console.error(e);
         return false;
     }
-}
-
-export function getGameScreenshotsUrls(
-    platform: string,
-    gameName: string
-): string[] {
-    var screenshots = [];
-    screenshots.push(getGameTitleScreenshotUrl(platform, gameName));
-    return screenshots.concat(
-        [1, 2, 3, 4].map((x) =>
-            getGameScreenshotImageURL(platform, gameName, x)
-        )
-    );
 }
 
 export function getGameImagePath(folderName: string, gameId: string): string {

--- a/src/renderer/components/FloatingContainer.tsx
+++ b/src/renderer/components/FloatingContainer.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+
+type FloatingContainerProps = {
+  floatingClassName?: string
+  children: JSX.Element | JSX.Element[];
+  onClick?: () => void;
+} & React.HTMLProps<HTMLDivElement>;
+
+export class FloatingContainer extends React.Component<FloatingContainerProps> {
+  render() {
+    return (
+      <div className='floating-container__wrapper'
+        { ...this.props }
+        onClick={this.props.onClick}>
+        <div className={`floating-container ${this.props.floatingClassName}`}>
+          {this.props.children}
+        </div>
+      </div>
+    );
+  }
+}
+
+export class BareFloatingContainer extends React.Component<FloatingContainerProps> {
+  render() {
+    return (
+      <div className='floating-container__wrapper'
+        { ...this.props }
+        onClick={this.props.onClick}>
+        {this.props.children}
+      </div>
+    );
+  }
+}

--- a/src/renderer/components/GameImageCarousel.tsx
+++ b/src/renderer/components/GameImageCarousel.tsx
@@ -68,11 +68,17 @@ export function GameImageCarousel(props: GameImageCarouselProps) {
                         break;
                     case FormattedGameMediaType.VIDEO:
                         innerElem = (
-                            <video
-                                key={props.imgKey}
-                                className="fill-image"
-                                muted
-                                src={`${getFileServerURL()}/${media.path}#t=0.1`} />
+                            <>
+                                <div className="game-image-carousel-wheel-preview-overlay">
+                                    <OpenIcon className="game-image-carousel-wheel-preview-overlay--icon" icon='play-circle' />
+                                </div>
+                                <video
+                                    key={props.imgKey}
+                                    className="fill-image"
+                                    muted
+                                    src={`${getFileServerURL()}/${media.path}#t=0.1`}>
+                                </video>
+                            </>
                         );
                         break;
                 }
@@ -107,7 +113,7 @@ export function GameImageCarousel(props: GameImageCarouselProps) {
                 return (
                     <img
                         key={props.imgKey}
-                        className="fill-image" 
+                        className="fill-image cursor" 
                         src={`${getFileServerURL()}/${selectedMedia.path}`}
                         onClick={() => props.onPreviewMedia(selectedMedia)}/>
                 )
@@ -115,7 +121,7 @@ export function GameImageCarousel(props: GameImageCarouselProps) {
                 return (
                     <video
                         key={props.imgKey}
-                        className="fill-image" 
+                        className="fill-image cursor" 
                         autoPlay
                         loop
                         muted

--- a/src/renderer/components/GameImageCarousel.tsx
+++ b/src/renderer/components/GameImageCarousel.tsx
@@ -1,0 +1,132 @@
+import { fixSlashes, getFileServerURL } from "@shared/Util";
+import { GameImages, IGameInfo } from "@shared/game/interfaces"
+import { useMemo, useState, useCallback } from "react";
+import React = require("react");
+import { OpenIcon } from "./OpenIcon";
+
+export type GameImageCarouselProps = {
+    images: GameImages;
+    platform: string;
+    key: string; // Ensures previous images are always replaced when the selected game changes
+    onScreenshotClick: (screenshotUrl: string) => void;
+}
+
+const IMAGE_COUNT = 4;
+
+export function GameImageCarousel(props: GameImageCarouselProps) {
+    const [selectedImageIdx, setSelectedImageIdx] = useState(0);
+    const [wheelPosition, setWheelPosition] = useState(0);
+    const [hoveredIndex, setHoveredIndex] = useState<number | null>(0);
+
+    // When the image changes, reset the selected elements
+    React.useEffect(() => {
+        setWheelPosition(0);
+        setSelectedImageIdx(0);
+    }, [props.images]);
+
+    const sortedImages = useMemo(() => {
+        return sortGameImages(props.images, props.platform)
+    }, [props.images, props.platform]);
+
+    // Hover functions to trigger the label to show
+    const handleMouseEnter = (index: number) => {
+        setHoveredIndex(index);
+    };
+
+    const handleMouseLeave = () => {
+        setHoveredIndex(null);
+    };
+
+    // Wheel arrow functions
+    const wheelMoveLeft = () => {
+        if (wheelPosition > 0) {
+            setWheelPosition(wheelPosition - 1);
+        }
+    };
+
+    const wheelMoveRight = () => {
+        if (wheelPosition < sortedImages.length - IMAGE_COUNT) {
+            setWheelPosition(wheelPosition + 1);
+        }
+    };
+
+    const imagePreviews = useMemo(() => {
+        return sortedImages
+            .slice(Math.min(wheelPosition, sortedImages.length - 1), Math.min(wheelPosition + IMAGE_COUNT, sortedImages.length))
+            .map((image, idx) => {
+                const selected = (wheelPosition + idx) === selectedImageIdx;
+
+                return (
+                    <div 
+                        key={`${props.key}-${idx}`} 
+                        style={{
+                            width: `${(1 / IMAGE_COUNT) * (100 - (IMAGE_COUNT * 2))}%`,
+                            marginLeft: '1%',
+                            marginRight: '1%'
+                        }}
+                        className={`game-image-carousel-wheel-preview ${selected && 'game-image-carousel-wheel-preview--selected'}`} 
+                        onMouseEnter={() => handleMouseEnter(idx)}
+                        onMouseLeave={handleMouseLeave}
+                        onClick={() => setSelectedImageIdx(idx + wheelPosition)}>
+                        <img className="fill-image" src={`${getFileServerURL()}/Images/${image.path}`} />
+                    </div>
+                );
+            });
+    }, [wheelPosition, sortedImages, selectedImageIdx]);
+
+    if (sortedImages.length === 0 || wheelPosition > sortedImages.length - 1|| selectedImageIdx > sortedImages.length - 1) {
+        return <></>; // Either no images, or the game just changed and state needs reset, let render happen at next state change instead
+    }
+
+    const selectedImage = sortedImages[selectedImageIdx];
+
+    console.log(selectedImage.path);
+    return (
+        <div className="game-image-carousel">
+            <div className="game-image-carousel-selected">
+                <img
+                    key={props.key}
+                    className="fill-image" src={`${getFileServerURL()}/Images/${selectedImage.path}`}
+                    onClick={() => props.onScreenshotClick(`${getFileServerURL()}/Images/${selectedImage.path}`)}/>
+            </div>
+            <div className="game-image-carousel-wheel">
+                {wheelPosition > 0 && (
+                    <div className="game-image-carousel-wheel-arrow" onClick={wheelMoveLeft}>
+                        <OpenIcon icon="arrow-left"/>
+                    </div>
+                )}
+                <div className="game-image-carousel-wheel-previews">
+                    {imagePreviews}
+                </div>
+                {wheelPosition < sortedImages.length - IMAGE_COUNT && (
+                    <div className="game-image-carousel-wheel-arrow" onClick={wheelMoveRight}>
+                        <OpenIcon icon="arrow-right"/>
+                    </div>
+                )}
+            </div>
+            <div className="game-image-carousel-label">
+                {hoveredIndex === null ? selectedImage.name : sortedImages[hoveredIndex].name}
+            </div>
+        </div>
+    );
+}
+
+type FormattedGameImage = {
+    name: string;
+    path: string;
+}
+
+function sortGameImages(images: GameImages, platform: string): FormattedGameImage[] {
+    const list: FormattedGameImage[] = [];
+
+    for (const category of Object.keys(images)) {
+        for (const filename of images[category]) {
+            list.push({
+                name: category,
+                path: fixSlashes(`${platform}/${filename}`)
+            })
+        }
+    }
+
+    return list;
+}

--- a/src/renderer/components/GameImageCarousel.tsx
+++ b/src/renderer/components/GameImageCarousel.tsx
@@ -72,7 +72,7 @@ export function GameImageCarousel(props: GameImageCarouselProps) {
                                 key={props.imgKey}
                                 className="fill-image"
                                 muted
-                                src={`${getFileServerURL()}/${media.path}#t=0.1`} /> // Preloads 0.1 seconds just to get the snapshot
+                                src={`${getFileServerURL()}/${media.path}#t=0.1`} />
                         );
                         break;
                 }
@@ -168,6 +168,7 @@ function sortGameMedia(media: GameMedia, platform: string): FormattedGameMedia[]
 
     // Add videos first
     if (media.video) {
+        console.log('VIDEO');
         list.push({
             name: "30 Second Demo",
             type: FormattedGameMediaType.VIDEO,

--- a/src/renderer/components/GameImageSplit.tsx
+++ b/src/renderer/components/GameImageSplit.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { formatString } from "@shared/utils/StringFormatter";
 import { ConfirmElement, ConfirmElementArgs } from "./ConfirmElement";
-import { ImagePreview } from "./ImagePreview";
+import { MediaPreview } from "./ImagePreview";
 import { OpenIcon } from "./OpenIcon";
 import { SimpleButton } from "./SimpleButton";
 import { englishTranslation } from "@renderer/lang/en";
@@ -95,7 +95,7 @@ export class GameImageSplit extends React.Component<
                             extra={[text, !!disabled]}
                         />
                         {showPreview ? (
-                            <ImagePreview
+                            <MediaPreview
                                 src={this.props.imgSrc}
                                 onCancel={this.onPreviewCancel}
                             />

--- a/src/renderer/components/ImagePreview.tsx
+++ b/src/renderer/components/ImagePreview.tsx
@@ -1,145 +1,81 @@
+import { getFileServerURL } from "@shared/Util";
 import * as React from "react";
-import * as ReactDOM from "react-dom";
+import { BareFloatingContainer } from "./FloatingContainer";
+import { FormattedGameMedia, FormattedGameMediaType } from "./GameImageCarousel";
 
-export type ImagePreviewProps = {
-    /** Source of the image to display. */
-    src?: string;
-    /** Called when the user attempts to cancel/close image preview. */
+export type MediaPreviewProps = {
+    /** Media to display. */
+    media: FormattedGameMedia;
+    /** Called when the user attempts to cancel/close media preview. */
     onCancel?: () => void;
 };
 
-export type ImagePreviewState = {
-    /** If the image should be scaled up to fill the entire preview space (if it is smaller than that space). */
-    scaleUp: boolean;
-    /** Original width of image (in pixels). */
-    imageWidth: number;
-    /** Original height of image (in pixels). */
-    imageHeight: number;
-    /** Width of border (in pixels). The border is the area between the preview space and the edge of the window. */
-    borderWidth: number;
-    /** Height of border (in pixels). The border is the area between the preview space and the edge of the window. */
-    borderHeight: number;
-};
+export function MediaPreview(props: MediaPreviewProps) {
+    const [scaleUp, setScaleUp] = React.useState(false);
 
-/** An overlay that covers the entire window and displays an image in the center. */
-export class ImagePreview extends React.Component<
-    ImagePreviewProps,
-    ImagePreviewState
-> {
-    borderRef: React.RefObject<HTMLDivElement> = React.createRef();
-    /** Parent element of the overlay root element. */
-    parent: HTMLElement;
-    /** Root element of the overlay. */
-    element: HTMLElement;
-
-    constructor(props: ImagePreviewProps) {
-        super(props);
-        this.state = {
-            scaleUp: false,
-            imageWidth: 0,
-            imageHeight: 0,
-            borderWidth: 0,
-            borderHeight: 0,
-        };
-        this.parent = document.body;
-        this.element = document.createElement("div");
+    const onClickImage = (event: React.MouseEvent<any>) => {
+        setScaleUp(!scaleUp);
+        event.preventDefault();
+        event.stopPropagation();
+        return false;
     }
 
-    componentDidUpdate(
-        prevProps: ImagePreviewProps,
-        prevState: ImagePreviewState,
-    ) {
-        if (this.props.src !== prevProps.src) {
-            this.updateBorderSize();
-        }
-    }
-
-    componentDidMount() {
-        this.parent.appendChild(this.element);
-        window.addEventListener("resize", this.updateBorderSize);
-        this.updateBorderSize();
-    }
-
-    componentWillUnmount() {
-        this.parent.removeChild(this.element);
-        window.removeEventListener("resize", this.updateBorderSize);
-    }
-
-    render() {
-        return ReactDOM.createPortal(
-            <div className="image-preview" onClick={this.onClickBackground}>
-                <div
-                    className="image-preview__border simple-center"
-                    onClick={this.onClickBackground}
-                    ref={this.borderRef}
-                >
-                    <div
-                        className="simple-center__inner simple-center__vertical-inner"
-                        onClick={this.onClickBackground}
-                    >
-                        <img
-                            className={
-                                "image-preview__image" +
-                                (this.state.scaleUp
-                                    ? " image-preview__image--fill"
-                                    : " image-preview__image--fit")
-                            }
-                            src={this.props.src}
-                            onClick={this.onClickImage}
-                            onLoad={this.onLoad}
-                            style={{ ...this.calculateSize() }}
-                        />
-                    </div>
-                </div>
-            </div>,
-            this.element,
-        );
-    }
-
-    /** Calculate the size the image should have, depending on the current state. */
-    calculateSize(): { width: number; height: number } {
-        const fixedScale = 2.0;
-        const { scaleUp, imageWidth, imageHeight, borderWidth, borderHeight } =
-            this.state;
-
-        let width = imageWidth * fixedScale;
-        let height = imageHeight * fixedScale;
-
-        const scale = Math.min(borderWidth / width, borderHeight / height);
-        if (scaleUp || scale < 1) {
-            width *= scale;
-            height *= scale;
-        }
-        return { width, height };
-    }
-
-    onClickImage = (): void => {
-        this.setState({ scaleUp: !this.state.scaleUp });
-    };
-
-    onClickBackground = (event: React.MouseEvent): void => {
-        if (event.target === event.currentTarget) {
-            if (this.props.onCancel) {
-                this.props.onCancel();
+    const renderedMedia = () => {
+        switch (props.media.type) {
+            case FormattedGameMediaType.IMAGE: {
+                return (
+                    <img
+                        className={
+                            "image-preview__image" +
+                            (scaleUp
+                                ? " image-preview__image--fill"
+                                : " image-preview__image--fit")
+                        }
+                        src={`${getFileServerURL()}/${props.media.path}`}
+                        onClick={onClickImage} />
+                );
+            }
+            case FormattedGameMediaType.VIDEO: {
+                return (
+                    <video
+                        controls
+                        autoPlay
+                        className={
+                            "image-preview__image" +
+                            (scaleUp
+                                ? " image-preview__image--fill"
+                                : " image-preview__image--fit")
+                        }
+                        src={`${getFileServerURL()}/${props.media.path}`}/>
+                );
             }
         }
-    };
+    }
 
-    updateBorderSize = (): void => {
-        const border = this.borderRef.current;
-        if (!border) {
-            throw new Error("Border is missing.");
+    const onClickBackground = (event: React.MouseEvent<HTMLDivElement>) => {
+        if (props.onCancel) {
+            props.onCancel();
         }
-        this.setState({
-            borderWidth: border.offsetWidth,
-            borderHeight: border.offsetHeight,
-        });
     };
 
-    onLoad = (event: React.SyntheticEvent<HTMLImageElement>): void => {
-        this.setState({
-            imageWidth: event.currentTarget.naturalWidth,
-            imageHeight: event.currentTarget.naturalHeight,
-        });
-    };
+    return (
+        <BareFloatingContainer>
+            <div className="image-preview-container" onClick={onClickBackground}>
+                <div style={{height: "97%"}}>
+                    <div className={
+                            "image-preview" +
+                            (scaleUp
+                                ? " image-preview--fill"
+                                : " image-preview--fit")
+                        }>
+                        {renderedMedia()}
+                    </div>
+                </div>
+                <div className="image-preview-label">
+                    {props.media.name}
+                </div>
+            </div>
+        </BareFloatingContainer>
+
+    )
 }

--- a/src/renderer/components/ImagePreview.tsx
+++ b/src/renderer/components/ImagePreview.tsx
@@ -60,8 +60,8 @@ export function MediaPreview(props: MediaPreviewProps) {
 
     return (
         <BareFloatingContainer>
-            <div className="image-preview-container" onClick={onClickBackground}>
-                <div style={{height: "97%"}}>
+            <div className="image-preview-container" style={{overflowY: scaleUp ? 'auto' : 'unset'}} onClick={onClickBackground}>
+                <div style={{height: scaleUp ? "auto" : "97%"}}>
                     <div className={
                             "image-preview" +
                             (scaleUp

--- a/src/renderer/components/RightBrowseSidebar.tsx
+++ b/src/renderer/components/RightBrowseSidebar.tsx
@@ -10,7 +10,6 @@ import { WithPreferencesProps } from "../containers/withPreferences";
 import { WithSearchProps } from "../containers/withSearch";
 import {
     getGameImagePath,
-    getGameScreenshotsUrls,
     resourceExists,
 } from "../Util";
 import { DropdownInputField } from "./DropdownInputField";
@@ -20,6 +19,7 @@ import { RightBrowseSidebarAddApp } from "./RightBrowseSidebarAddApp";
 import { getFileServerURL } from "@shared/Util";
 import { openContextMenu } from "@main/Util";
 import { englishTranslation } from "@renderer/lang/en";
+import { GameImageCarousel } from "./GameImageCarousel";
 
 type OwnProps = {
     /** Currently selected game (if any) */
@@ -45,7 +45,6 @@ export type RightBrowseSidebarProps = OwnProps &
 type RightBrowseSidebarState = {
     /** If a preview of the current game's screenshot should be shown. */
     screenshotPreviewUrl: string;
-    screenshots: string[];
 };
 
 export interface RightBrowseSidebar {}
@@ -60,41 +59,8 @@ export class RightBrowseSidebar extends React.Component<
     constructor(props: RightBrowseSidebarProps) {
         super(props);
         this.state = {
-            screenshotPreviewUrl: "",
-            screenshots: [],
+            screenshotPreviewUrl: ""
         };
-    }
-
-    async getExistingScreenshotsList(
-        game: IGameInfo | null
-    ): Promise<string[]> {
-        if (!game) return [];
-
-        var allScreenshots = getGameScreenshotsUrls(game.platform, game.title);
-        var existingScreenshots = [];
-
-        for (var s of allScreenshots) {
-            if (await resourceExists(s)) existingScreenshots.push(s);
-        }
-        return existingScreenshots;
-    }
-
-    componentDidUpdate(prevProps: RightBrowseSidebarProps): void {
-        if (this.props.currentGame !== prevProps.currentGame) {
-            if (this.props.currentGame) {
-                this.getExistingScreenshotsList(this.props.currentGame).then(
-                    (screenshots) => {
-                        this.setState({
-                            screenshots: screenshots,
-                        });
-                    }
-                );
-            } else {
-                this.setState({
-                    screenshots: [],
-                });
-            }
-        }
     }
 
     render() {
@@ -161,6 +127,16 @@ export class RightBrowseSidebar extends React.Component<
                             </div>
                         </div>
                     </div>
+
+                    {/* -- Game Image Carousel -- */}
+                    <div className="browse-right-sidebar__section">
+                        <GameImageCarousel
+                            key={game.id}
+                            images={game.images}
+                            platform={game.platform} 
+                            onScreenshotClick={this.onScreenshotClick} />
+                    </div>
+
                     {/* -- Most Fields -- */}
                     <div className="browse-right-sidebar__section">
                         <div className="browse-right-sidebar__row browse-right-sidebar__row--one-line">
@@ -253,31 +229,6 @@ export class RightBrowseSidebar extends React.Component<
                                 }
                             />
                         </div>
-                    </div>
-                    {/* -- Screenshot -- */}
-                    <div className="browse-right-sidebar__section">
-                        {this.state.screenshots.map((s, idx) => (
-                            <div
-                                className="browse-right-sidebar__row"
-                                key={`screenshot-row-div-${idx}`}
-                            >
-                                <div
-                                    className="browse-right-sidebar__row__screenshot"
-                                    key={`screenshot-div-${idx}`}
-                                    onContextMenu={this.onScreenshotContextMenu}
-                                >
-                                    <img
-                                        className="browse-right-sidebar__row__screenshot-image"
-                                        alt="" // Hide the broken link image if source is not found
-                                        src={s}
-                                        key={`screenshot-img-${idx}`}
-                                        onClick={() =>
-                                            this.onScreenshotClick(s)
-                                        }
-                                    />
-                                </div>
-                            </div>
-                        ))}
                     </div>
                     {/* -- Playlist Game Entry Notes -- */}
                     {gamePlaylistEntry ? (

--- a/src/renderer/components/RightBrowseSidebar.tsx
+++ b/src/renderer/components/RightBrowseSidebar.tsx
@@ -1,25 +1,23 @@
-import { MenuItemConstructorOptions } from "electron";
 import { BrowserWindow, shell } from "@electron/remote";
-import * as React from "react";
-import { BackIn, LaunchAddAppData, LaunchGameData } from "@shared/back/types";
-import { LOGOS, SCREENSHOTS } from "@shared/constants";
-import { wrapSearchTerm } from "@shared/game/GameFilter";
-import { IAdditionalApplicationInfo, IGameInfo } from "@shared/game/interfaces";
-import { GamePlaylistEntry, PickType } from "@shared/interfaces";
-import { WithPreferencesProps } from "../containers/withPreferences";
-import { WithSearchProps } from "../containers/withSearch";
-import {
-    getGameImagePath,
-    resourceExists,
-} from "../Util";
-import { DropdownInputField } from "./DropdownInputField";
-import { ImagePreview } from "./ImagePreview";
-import { InputField } from "./InputField";
-import { RightBrowseSidebarAddApp } from "./RightBrowseSidebarAddApp";
-import { getFileServerURL } from "@shared/Util";
 import { openContextMenu } from "@main/Util";
 import { englishTranslation } from "@renderer/lang/en";
-import { GameImageCarousel } from "./GameImageCarousel";
+import { getFileServerURL } from "@shared/Util";
+import { BackIn, LaunchAddAppData, LaunchGameData } from "@shared/back/types";
+import { LOGOS, SCREENSHOTS } from "@shared/constants";
+import { GameMedia, IAdditionalApplicationInfo, IGameInfo } from "@shared/game/interfaces";
+import { GamePlaylistEntry } from "@shared/interfaces";
+import { MenuItemConstructorOptions } from "electron";
+import * as React from "react";
+import {
+    getGameImagePath
+} from "../Util";
+import { WithPreferencesProps } from "../containers/withPreferences";
+import { WithSearchProps } from "../containers/withSearch";
+import { DropdownInputField } from "./DropdownInputField";
+import { FormattedGameMedia, GameImageCarousel } from "./GameImageCarousel";
+import { MediaPreview } from "./ImagePreview";
+import { InputField } from "./InputField";
+import { RightBrowseSidebarAddApp } from "./RightBrowseSidebarAddApp";
 
 type OwnProps = {
     /** Currently selected game (if any) */
@@ -43,8 +41,8 @@ export type RightBrowseSidebarProps = OwnProps &
     WithSearchProps;
 
 type RightBrowseSidebarState = {
-    /** If a preview of the current game's screenshot should be shown. */
-    screenshotPreviewUrl: string;
+    /** If a preview of the current game's selected media. */
+    previewMedia?: FormattedGameMedia;
 };
 
 export interface RightBrowseSidebar {}
@@ -58,9 +56,7 @@ export class RightBrowseSidebar extends React.Component<
 
     constructor(props: RightBrowseSidebarProps) {
         super(props);
-        this.state = {
-            screenshotPreviewUrl: ""
-        };
+        this.state = {};
     }
 
     render() {
@@ -131,10 +127,10 @@ export class RightBrowseSidebar extends React.Component<
                     {/* -- Game Image Carousel -- */}
                     <div className="browse-right-sidebar__section">
                         <GameImageCarousel
-                            key={game.id}
-                            images={game.images}
+                            imgKey={game.id}
+                            media={game.media}
                             platform={game.platform} 
-                            onScreenshotClick={this.onScreenshotClick} />
+                            onPreviewMedia={this.onPreviewMedia} />
                     </div>
 
                     {/* -- Most Fields -- */}
@@ -286,11 +282,11 @@ export class RightBrowseSidebar extends React.Component<
                         </div>
                     )}
 
-                    {/* -- Screenshot Preview -- */}
-                    {this.state.screenshotPreviewUrl ? (
-                        <ImagePreview
-                            src={this.state.screenshotPreviewUrl}
-                            onCancel={this.onScreenshotPreviewClick}
+                    {/* -- Media Preview -- */}
+                    {this.state.previewMedia ? (
+                        <MediaPreview
+                            media={this.state.previewMedia}
+                            onCancel={this.onPreviewMediaClick}
                         />
                     ) : undefined}
                 </div>
@@ -390,11 +386,11 @@ export class RightBrowseSidebar extends React.Component<
         this.forceUpdate();
     };
 
-    onScreenshotClick = (screenshotUrl: string): void => {
-        this.setState({ screenshotPreviewUrl: screenshotUrl });
+    onPreviewMedia = (media: FormattedGameMedia): void => {
+        this.setState({ previewMedia: media });
     };
 
-    onScreenshotPreviewClick = (): void => {
-        this.setState({ screenshotPreviewUrl: "" });
+    onPreviewMediaClick = (): void => {
+        this.setState({ previewMedia: undefined });
     };
 }

--- a/src/shared/game/GameInfo.ts
+++ b/src/shared/game/GameInfo.ts
@@ -36,6 +36,7 @@ export class GameInfo {
             favorite: false,
             rating: "",
             region: "",
+            images: {},
         };
     }
 

--- a/src/shared/game/GameInfo.ts
+++ b/src/shared/game/GameInfo.ts
@@ -36,7 +36,10 @@ export class GameInfo {
             favorite: false,
             rating: "",
             region: "",
-            images: {},
+            media: {
+                images: {},
+                video: "",
+            },
         };
     }
 

--- a/src/shared/game/GameParser.ts
+++ b/src/shared/game/GameParser.ts
@@ -103,6 +103,7 @@ export class GameParser {
             region: unescapeHTML(data.Region),
             thumbnailPath: "",
             installed: false,
+            images: {},
         };
     }
 

--- a/src/shared/game/GameParser.ts
+++ b/src/shared/game/GameParser.ts
@@ -103,7 +103,10 @@ export class GameParser {
             region: unescapeHTML(data.Region),
             thumbnailPath: "",
             installed: false,
-            images: {},
+            media: {
+                images: {},
+                video: "",
+            },
         };
     }
 

--- a/src/shared/game/interfaces.ts
+++ b/src/shared/game/interfaces.ts
@@ -60,6 +60,14 @@ export interface IPureGameInfo {
     maxPlayers?: number;
 }
 
+export type GameImages = {
+    [key: string]: Array<string> 
+};
+
+export type GameImagesCollection = {
+    [key: string]: GameImages; // "Box - Front" - "<GameTitle>" - "<FilePath>"
+}
+
 /** Represents the meta data for a single Game (including temporary data) */
 export interface IGameInfo extends IPureGameInfo {
     /** Library this game belongs to */
@@ -76,6 +84,7 @@ export interface IGameInfo extends IPureGameInfo {
     thumbnailPath: string;
     configurationPath: string;
     installed: boolean;
+    images: GameImages;
 }
 
 /** Represents the meta data for a single additional application */

--- a/src/shared/game/interfaces.ts
+++ b/src/shared/game/interfaces.ts
@@ -61,12 +61,21 @@ export interface IPureGameInfo {
 }
 
 export type GameImages = {
-    [key: string]: Array<string> 
+    [key: string]: Array<string>;
 };
+
+export type GameMedia = {
+    images: GameImages;
+    video: string;
+}
 
 export type GameImagesCollection = {
     [key: string]: GameImages; // "Box - Front" - "<GameTitle>" - "<FilePath>"
 }
+
+export type GameVideosCollection = {
+    [key: string]: string; // "<game title> (from app path)" - "<FilePath>" 
+};
 
 /** Represents the meta data for a single Game (including temporary data) */
 export interface IGameInfo extends IPureGameInfo {
@@ -80,11 +89,12 @@ export interface IGameInfo extends IPureGameInfo {
     manualPath: string;
     /** Path to music played in menu */
     musicPath: string;
-    /** Thumbnail path to be displayed in game list in grid mode*/
+    /** Thumbnail path to be displayed in game list in grid mode */
     thumbnailPath: string;
     configurationPath: string;
     installed: boolean;
-    images: GameImages;
+    /** Collection of game media*/
+    media: GameMedia;
 }
 
 /** Represents the meta data for a single additional application */

--- a/src/shared/platform/interfaces.ts
+++ b/src/shared/platform/interfaces.ts
@@ -1,5 +1,6 @@
-import { IGameCollection } from "../game/interfaces";
-import { removeLowestDirectory } from "../../shared/Util";
+import { GameImages, GameImagesCollection, IGameCollection, IGameInfo } from "../game/interfaces";
+import { fixSlashes, removeLowestDirectory } from "../../shared/Util";
+import { getLaunchboxFilename } from "@back/game/LaunchBoxHelper";
 
 export type PlatformInfo = {
     name: string;

--- a/static/window/styles/core.css
+++ b/static/window/styles/core.css
@@ -311,15 +311,26 @@ body {
 }
 
 /* ------ Image Preview ------ */
-.image-preview {
-  /* Fill entire screen */
-  position: absolute;
-  left: 0;
-  top: 0;
+.image-preview-container {
   width: 100%;
   height: 100%;
-  /* Pimp */
+  text-align: center;
+  display: flex;
+  flex-direction: column;
   padding: 2rem;
+}
+.image-preview {
+  /* Fill entire screen */
+  justify-content: center;
+  width: 100%;
+  display: flex;
+  /* Pimp */
+}
+.image-preview--fill {
+  height: 100%;
+}
+.image-preview--fit {
+  max-height: 100%;
 }
 .image-preview * {
   user-select: none;
@@ -330,9 +341,16 @@ body {
 }
 .image-preview__image--fill {
   cursor: zoom-out;
+  object-fit: contain;
 }
 .image-preview__image--fit {
   cursor: zoom-in;
+  object-fit: contain;
+}
+.image-preview-label {
+  font-weight: bold;
+  font-size: 1.25em;
+  margin-top: 0.5rem;
 }
 
 
@@ -2010,4 +2028,31 @@ body {
   max-height: 100%;
   max-width: 100%;
   object-fit: contain;
+}
+
+/** Floating Containers */
+.floating-container__wrapper {
+  position: fixed;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+.floating-container {
+  text-align: center;
+  padding: 1rem;
+  border: 1px solid;
+  overflow: auto;
+  max-height: 90%;
+  max-width: 90%;
+}
+
+.page-wrap {
+  width: 100%;
+  height: 100%;
 }

--- a/static/window/styles/core.css
+++ b/static/window/styles/core.css
@@ -1958,3 +1958,56 @@ body {
 .splash-screen__status-header {
   font-size: 2.5rem;
 }
+
+/** Game Image Carousel */
+.game-image-carousel-selected {
+  user-select: none;
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  height: 25vh;
+  margin-bottom: 0.5rem;
+}
+
+.game-image-carousel-wheel {
+  width: 100%;
+  height: 10vh;
+  display: flex;
+}
+
+.game-image-carousel-wheel-arrow {
+  user-select: none;
+  padding-left: 0.2rem;
+  padding-right: 0.2rem;
+  max-width: 10%;
+  flex-grow: 0;
+  height: 100%;
+  display: flex;
+  align-items: center;
+}
+
+.game-image-carousel-wheel-preview {
+  user-select: none;
+  display: flex;
+  justify-content: center;
+  flex-grow: 1;
+}
+
+.game-image-carousel-wheel-previews {
+  display: flex;
+  justify-content: space-between;
+  flex-grow: 1;
+}
+
+.game-image-carousel-label {
+  font-weight: bold;
+  text-align: center;
+  margin-top: 0.2rem;
+  margin-bottom: 0.2rem;
+}
+
+.fill-image {
+  max-height: 100%;
+  max-width: 100%;
+  object-fit: contain;
+}

--- a/static/window/styles/core.css
+++ b/static/window/styles/core.css
@@ -2006,9 +2006,26 @@ body {
 
 .game-image-carousel-wheel-preview {
   user-select: none;
+  cursor: pointer;
   display: flex;
   justify-content: center;
   flex-grow: 1;
+  position: relative;
+}
+
+.game-image-carousel-wheel-preview-overlay {
+  position: absolute;
+  height: 100%;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+.game-image-carousel-wheel-preview-overlay--icon {
+  opacity: 90%;
+  width: 65%;
+  height: 65%;
+  filter: drop-shadow(1px 1px 5px var(--layout__game-grid-icon-shadow));
 }
 
 .game-image-carousel-wheel-previews {
@@ -2055,4 +2072,8 @@ body {
 .page-wrap {
   width: 100%;
   height: 100%;
+}
+
+.cursor {
+  cursor: pointer;
 }

--- a/static/window/styles/fancy.css
+++ b/static/window/styles/fancy.css
@@ -53,6 +53,7 @@
   --layout__game-item-background-selected:       #791c76;
   --layout__game-item-background-selected-hover: #a72aa2;
   --layout__game-item-thumb-image-rendering:       normal; /* Used to set the "image-rendering" of the thumbnail. */
+  --layout__game-grid-icon-shadow:               black;
   /* Browse Sidebar(s) */
   --layout__browse-sidebar-background:         #181819;
   --layout__browse-sidebar-divider-background: #131313;
@@ -876,4 +877,9 @@ body {
 .floating-container {
   background-color: var(--layout__home-page-box-background);
   border-color: var(--layout__home-page-box-border);
+}
+
+/** Fancy shadow effect on platform icon */
+.game-grid-item__thumb__icons {
+  filter: drop-shadow(1px 1px 4px var(--layout__game-grid-icon-shadow));
 }

--- a/static/window/styles/fancy.css
+++ b/static/window/styles/fancy.css
@@ -851,3 +851,25 @@ body {
 .splash-screen__status {
   color: var(--layout__primary-text-color);
 }
+
+/* --- Game Image Carousel --- */
+.game-image-carousel-wheel-arrow {
+  background-color: var(--layout__secondary-background);
+}
+.game-image-carousel-wheel-arrow:hover {
+  background-color: var(--layout__slider-background-hover);
+}
+.game-image-carousel-wheel-arrow:active {
+  background-color: var(--layout__slider-background-active);
+}
+.game-image-carousel-wheel-preview:hover {
+  border-bottom: 3px solid var(--layout__slider-background-hover);
+  padding-bottom: 2px;
+  border-radius: 2px;
+}
+.game-image-carousel-wheel-preview:active,
+.game-image-carousel-wheel-preview--selected {
+  border-bottom: 3px solid var(--layout__slider-background);
+  padding-bottom: 2px;
+  border-radius: 2px;
+}

--- a/static/window/styles/fancy.css
+++ b/static/window/styles/fancy.css
@@ -32,6 +32,7 @@
   --layout__secondary-background:  #2d2d30;
   --layout__tertiary-background:   #141417;
   --layout__quaternary-background: #242428;
+  --layout__background-faded:      rgba(0, 0, 0, 0.8);
   /* Outline Color */
   --layout__primary-outline-color: #47474d;
   /* Scrollbar */
@@ -272,13 +273,6 @@ body {
 .log__source--curation {
   color: var(--layout__log-source-curation);
 }
-
-
-/* ------ Image Preview ------ */
-.image-preview {
-  background-color: rgba(0, 0, 0, 0.8);
-}
-
 
 /* ------ Main Layout ------ */
 .root {
@@ -872,4 +866,14 @@ body {
   border-bottom: 3px solid var(--layout__slider-background);
   padding-bottom: 2px;
   border-radius: 2px;
+}
+
+/** Floating Containers */
+.floating-container__wrapper {
+  background-color: var(--layout__background-faded);
+}
+
+.floating-container {
+  background-color: var(--layout__home-page-box-background);
+  border-color: var(--layout__home-page-box-border);
 }


### PR DESCRIPTION
Adds an Media Carousel to the Game Sidebar, currently presents them in order of video, then images in alphabetical order.

Videos in the sidebar play on a muted loop with controls disabled. Clicking it opens it in the media preview whcih unmutes and enables controls. Byte chunk header support was added to the file server to allow the seek bar to work.

It only checks the top level of `Videos` for the 30 second demo currently.

![image](https://github.com/margorski/exodos-launcher/assets/1308979/04eec821-8a5b-41b9-b1bc-1d4b45455aad)

All media for each platform are read at startup in a single sweep, and stored in maps. These maps are used to populate the `media` field on each game object with fairly good performance.

LaunchBox removes information from image filenames, so it does the same by matching a formatted game title to the filename, which fixes thumbnails which previously didn't have their images load.

Game videos aren't properly stored in the game metadata, so instread we extract the predictable filename based on the application path.

Thumbnails are now also populated in order of preference, this order and which images are valid for a thumbnail can be edited in an array. The game grid does not support other media types.