### PR TITLE
Sync install state

### DIFF
--- a/src/back/index.ts
+++ b/src/back/index.ts
@@ -844,6 +844,24 @@ function exit() {
     }
 }
 
+export function onGameUpdated(game: IGameInfo): void {
+    if (!isErrorProxy(state.server)) {
+        const res: WrappedResponse<IGameInfo> = {
+            id: "",
+            type: BackOut.GAME_CHANGE,
+            data: game
+        };
+        const message = JSON.stringify(res);
+        state.server.clients.forEach((socket) => {
+            if (socket.onmessage === onMessageWrap) {
+                console.log(`Broadcast: ${BackOut[res.type]}`);
+                // (Check if authorized)
+                socket.send(message);
+            }
+        });
+    }
+}
+
 function respond<T>(target: WebSocket, response: WrappedResponse<T>): void {
     target.send(JSON.stringify(response));
 }

--- a/src/back/playlist/PlaylistManager.ts
+++ b/src/back/playlist/PlaylistManager.ts
@@ -5,6 +5,7 @@ import { PlaylistFile } from "./PlaylistFile";
 import { LogFunc } from "@back/types";
 import { GamePlaylist, GamePlaylistEntry } from "@shared/interfaces";
 import { GamePlatform } from "@shared/platform/interfaces";
+import { INSTALLED_GAMES_PLAYLIST_PREFIX } from "@shared/game/GameFilter";
 
 export type PlaylistUpdatedFunc = (playlist: GamePlaylist) => void;
 export interface PlaylistManagerOpts {
@@ -54,7 +55,6 @@ export class PlaylistManager {
     }
 
     public addInstalledGamesPlaylist(
-        games: GamePlaylistEntry[],
         platform: GamePlatform
     ) {
         if (!this._initialized) {
@@ -69,26 +69,16 @@ export class PlaylistManager {
             return;
         }
 
-        const playlistDummyFilename = `${platform.name}_installedgames`;
-
-        const existingPlaylistIndex = this.playlists.findIndex(
-            (p) => p.filename === playlistDummyFilename
-        );
-        const playlist =
-            existingPlaylistIndex >= 0
-                ? this.playlists.splice(existingPlaylistIndex, 1)[0]
-                : {
-                      title: "Installed games",
-                      description: "A list of installed games.",
-                      author: "",
-                      icon: "",
-                      library: platform.name,
-                      filename: playlistDummyFilename,
-                      games: [],
-                  };
-        playlist.games = games;
-        this.playlists.unshift(playlist);
-        this._opts?.onPlaylistAddOrUpdate(playlist);
+        // Add a stub playlist for installed games, we'll use special behaviour when reading later
+        this.playlists.unshift({
+            title: `Installed games (${platform.name})`,
+            description: "A list of installed games.",
+            author: "",
+            icon: "",
+            library: platform.name,
+            filename: `${INSTALLED_GAMES_PLAYLIST_PREFIX}_${platform.name}`,
+            games: [],
+        });
     }
 
     private async _onPlaylistAddOrChange(

--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -27,7 +27,7 @@ import {
 } from "@shared/back/types";
 import { BrowsePageLayout } from "@shared/BrowsePageLayout";
 import { APP_TITLE } from "@shared/constants";
-import { UNKNOWN_LIBRARY } from "@shared/game/interfaces";
+import { IGameInfo, UNKNOWN_LIBRARY } from "@shared/game/interfaces";
 import { ExodosBackendInfo, GamePlaylist, WindowIPC } from "@shared/interfaces";
 import { getLibraryItemTitle } from "@shared/library/util";
 import { memoizeOne } from "@shared/memoize";
@@ -105,6 +105,8 @@ export type AppState = {
     updateInfo: UpdateInfo | undefined;
     /** Exodos backend info for displaying at homepage  */
     exodosBackendInfo: ExodosBackendInfo | undefined;
+    /** Key to force refresh of current game */
+    currentGameRefreshKey: number;
 };
 
 export class App extends React.Component<AppProps, AppState> {
@@ -167,6 +169,7 @@ export class App extends React.Component<AppProps, AppState> {
             updateInfo: undefined,
             order,
             exodosBackendInfo: undefined,
+            currentGameRefreshKey: 0,
         };
 
         // Initialize app
@@ -562,6 +565,12 @@ export class App extends React.Component<AppProps, AppState> {
                         this.setState({ themeList: resData });
                     }
                     break;
+                case BackOut.GAME_CHANGE:
+                    {
+                        // We don't track selected game here, so we'll just force a game update anyway
+                        this.setState({ currentGameRefreshKey: this.state.currentGameRefreshKey + 1 });
+                    }
+                    break;
             }
         });
 
@@ -721,6 +730,7 @@ export class App extends React.Component<AppProps, AppState> {
             themeList: this.state.themeList,
             updateInfo: this.state.updateInfo,
             exodosBackendInfo: this.state.exodosBackendInfo,
+            currentGameRefreshKey: this.state.currentGameRefreshKey,
         };
         // Render
         return (

--- a/src/renderer/components/pages/BrowsePage.tsx
+++ b/src/renderer/components/pages/BrowsePage.tsx
@@ -52,6 +52,8 @@ type OwnProps = {
     clearSearch: () => void;
     /** "Route" of the currently selected library (empty string means no library). */
     gameLibrary: string;
+    /** Key to force game refresh */
+    refreshKey: number;
 };
 
 export type BrowsePageProps = OwnProps & WithPreferencesProps;
@@ -156,6 +158,10 @@ export class BrowsePage extends React.Component<
                 currentGame: undefined,
                 currentAddApps: undefined,
             });
+        }
+        // Cheap hack to force the game to update if a key changes
+        if (prevProps.refreshKey !== this.props.refreshKey) {
+            this.updateCurrentGameAndAddApps();
         }
     }
 
@@ -287,15 +293,11 @@ export class BrowsePage extends React.Component<
     }
 
     private isCurrentGameInstalled = () => {
-        if (this.props.playlists.length === 0 || !this.state.currentGame)
-            return false;
-        const gameId = this.state.currentGame.id;
-
-        return this.isGameInstalled(gameId);
+        if (this.state.currentGame) {
+            return this.state.currentGame.installed;
+        }
+        return false;
     };
-
-    private isGameInstalled = (gameId: string) =>
-        this.props.playlists[0].games.findIndex((g) => g.id === gameId) !== -1;
 
     private noRowsRendererMemo = memoizeOne(() => {
         const strings = englishTranslation.browse;

--- a/src/renderer/router.tsx
+++ b/src/renderer/router.tsx
@@ -47,6 +47,7 @@ export type AppRouterProps = {
     themeList: Theme[];
     updateInfo: UpdateInfo | undefined;
     exodosBackendInfo: ExodosBackendInfo | undefined;
+    currentGameRefreshKey: number;
 };
 
 export class AppRouter extends React.Component<AppRouterProps> {
@@ -74,6 +75,7 @@ export class AppRouter extends React.Component<AppRouterProps> {
             onSelectGame: this.props.onSelectGame,
             onSelectPlaylist: this.props.onSelectPlaylist,
             gameLibrary: this.props.gameLibrary,
+            refreshKey: this.props.currentGameRefreshKey,
         };
         const configProps: ConnectedConfigPageProps = {
             themeList: this.props.themeList,

--- a/src/shared/back/types.ts
+++ b/src/shared/back/types.ts
@@ -53,6 +53,7 @@ export enum BackOut {
     THEME_LIST_CHANGE,
     PLAYLIST_UPDATE,
     PLAYLIST_REMOVE,
+    GAME_CHANGE,
     QUIT,
 }
 

--- a/src/shared/game/GameFilter.ts
+++ b/src/shared/game/GameFilter.ts
@@ -2,6 +2,8 @@ import { GamePlaylist } from "../interfaces";
 import { GameOrderBy, GameOrderReverse } from "../order/interfaces";
 import { IGameInfo } from "./interfaces";
 
+export const INSTALLED_GAMES_PLAYLIST_PREFIX = "!installedgames!"; // Some weird name that won't collide with real playlists
+
 type OrderFn = (a: IGameInfo, b: IGameInfo) => number;
 
 /** Order games by their order title alphabetically (ascending) */
@@ -153,17 +155,29 @@ function filterPlaylist(
     if (!playlist) {
         return games;
     }
-    const filteredGames: IGameInfo[] = [];
-    for (let gameEntry of playlist.games) {
-        const id = gameEntry.id;
-        for (let game of games) {
-            if (game.id === id) {
-                filteredGames.push(game);
-                break;
+
+    // Installed playlists are a special case
+    if (playlist.filename.startsWith(INSTALLED_GAMES_PLAYLIST_PREFIX)) {
+        // Purely rely on games installed state for these
+        const platformName = playlist.filename.split('_').slice(1).join('_');
+        return games.filter(g => g.installed && g.platform === platformName);
+    } else {
+        const filteredGames: IGameInfo[] = [];
+
+        // Add games normally
+        for (let gameEntry of playlist.games) {
+            const id = gameEntry.id;
+            for (let game of games) {
+                if (game.id === id) {
+                    filteredGames.push(game);
+                    break;
+                }
             }
         }
+
+        return filteredGames;
     }
-    return filteredGames;
+
 }
 
 /**

--- a/src/shared/platform/interfaces.ts
+++ b/src/shared/platform/interfaces.ts
@@ -26,7 +26,7 @@ export class GamePlatform {
 
     get isGamePlatform(): boolean {
         return (
-            this.collection.games.length > 0 &&
+            Object.keys(this.collection.games).length > 0 &&
             !!this.collection.games[0].configurationPath
         );
     }


### PR DESCRIPTION
Currently the games install state fails to update when the installed folder is detected.

This uses a cheap workaround to properly find the newly installed game, then sends the game info to the frontend to force it to update.

Since state is held in BrowsePage, we force the current game to refresh regardless of what it is instead of trying to figure out if the changed game actually is the current game.

This also changes the installed games playlist to be blank, and create with a unique dummy filename. Instead of populating it with games, the filter function will use the `installed` flag on games to determine whether to include or not.

Games now check their install state immediately when they are parsed.

Uninstalling a game will not reflect the change in the current Installed Games browse page results until the playlist is un-selected then re-selected, but this is a fairly rare case. You'll never install a game when the playlist is open so the reverse doesn't occur.