### PR TITLE
Make install state work for Win9x too

### DIFF
--- a/src/shared/game/GameParser.ts
+++ b/src/shared/game/GameParser.ts
@@ -125,8 +125,7 @@ export class GameParser {
          * xml root: eXo/eXoDOS/!dos/1Ton
          * Capture dirname `1Ton` and compare that instead
          *  */
-        const parts = fixSlashes(game.rootFolder).split("/");
-        parts.splice(parts.length - 2, 1);
+        const parts = fixSlashes(game.rootFolder).split("/").filter((word) => word[0] != "!");
         const gameDataPath = path.join(exodosPath, parts.join("/"));
         game.installed = fs.existsSync(gameDataPath);
         return game;


### PR DESCRIPTION
Exo's Win9x project isn't fully built out for Linux yet, but I've been doing some experiments rigging it up myself. The main issue is games now have a `/year/` folder included in their path. We can make the installed game check a little more flexible to allow for this in addition to the original game paths.